### PR TITLE
WIP: Make shrine_images not flutter specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # See https://www.dartlang.org/tools/private-files.html
 
 # Files and directories created by pub
+.dart_tool/
 .packages
-.pub/
 build/
 # If you're building an application, you may want to check-in your pubspec.lock
 pubspec.lock

--- a/shrine_images/lib/shrine_images.dart
+++ b/shrine_images/lib/shrine_images.dart
@@ -12,13 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Needed to get path of this package.
+import 'dart:mirrors';
 import 'dart:io';
 
 class ShrineImages {
-  List<String> get imageNames => List<String>.unmodifiable(_imageNames);
+  List<String> get imageNames => List<String>.unmodifiable(_imagenames);
 
   ShrineImage operator [](String name) {
-    if (!_imageNames.contains(name)) {
+    if (!_imagenames.contains(name)) {
       throw Exception('Unknown image "$name"');
     }
     return ShrineImage._(name);
@@ -26,15 +28,16 @@ class ShrineImages {
 }
 
 class ShrineImage {
-  ShrineImage._(this._filename);
-  final String _filename;
+  ShrineImage._(this._imagename);
+  final Uri baseUri = currentMirrorSystem().libraries['shrine_images'].uri;
+  final String _imagename;
 
-  Stream<List<int>> get image1x => File(_filename).openRead();
-  Stream<List<int>> get image2x => File('2.0x/$_filename').openRead();
-  Stream<List<int>> get image3x => File('3.0x/$_filename').openRead();
+  File get image1x => File('$baseUri/$_imagename');
+  File get image2x => File('$baseUri/2.0x/$_imagename');
+  File get image3x => File('$baseUri/3.0x/$_imagename');
 }
 
-const List<String> _imageNames = [
+const List<String> _imagenames = [
   '0-0.jpg',
   '1-0.jpg',
   '2-0.jpg',

--- a/shrine_images/lib/shrine_images.dart
+++ b/shrine_images/lib/shrine_images.dart
@@ -1,0 +1,82 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import 'dart:io';
+
+class ShrineImages {
+  List<String> get imageNames => List<String>.unmodifiable(_imageNames);
+
+  ShrineImage operator [](String name) {
+    if (!_imageNames.contains(name)) {
+      throw Exception('Unknown image "$name"');
+    }
+
+    return ShrineImage._(
+      name,
+      File('$name'),
+      File('2.0x/$name'),
+      File('3.0x/$name'),
+    );
+  }
+}
+
+class ShrineImage {
+  ShrineImage._(this.filename, this.image1x, this.image2x, this.image3x);
+  final String filename;
+  final File image1x;
+  final File image2x;
+  final File image3x;
+}
+
+const List<String> _imageNames = [
+  '0-0.jpg',
+  '1-0.jpg',
+  '2-0.jpg',
+  '3-0.jpg',
+  '4-0.jpg',
+  '5-0.jpg',
+  '6-0.jpg',
+  '7-0.jpg',
+  '8-0.jpg',
+  '9-0.jpg',
+  '10-0.jpg',
+  '11-0.jpg',
+  '12-0.jpg',
+  '13-0.jpg',
+  '14-0.jpg',
+  '15-0.jpg',
+  '16-0.jpg',
+  '17-0.jpg',
+  '18-0.jpg',
+  '19-0.jpg',
+  '20-0.jpg',
+  '21-0.jpg',
+  '22-0.jpg',
+  '23-0.jpg',
+  '24-0.jpg',
+  '25-0.jpg',
+  '26-0.jpg',
+  '27-0.jpg',
+  '28-0.jpg',
+  '29-0.jpg',
+  '30-0.jpg',
+  '31-0.jpg',
+  '32-0.jpg',
+  '33-0.jpg',
+  '34-0.jpg',
+  '35-0.jpg',
+  '36-0.jpg',
+  '37-0.jpg',
+];

--- a/shrine_images/lib/shrine_images.dart
+++ b/shrine_images/lib/shrine_images.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 import 'dart:io';
 
 class ShrineImages {
@@ -22,22 +21,17 @@ class ShrineImages {
     if (!_imageNames.contains(name)) {
       throw Exception('Unknown image "$name"');
     }
-
-    return ShrineImage._(
-      name,
-      File('$name'),
-      File('2.0x/$name'),
-      File('3.0x/$name'),
-    );
+    return ShrineImage._(name);
   }
 }
 
 class ShrineImage {
-  ShrineImage._(this.filename, this.image1x, this.image2x, this.image3x);
-  final String filename;
-  final File image1x;
-  final File image2x;
-  final File image3x;
+  ShrineImage._(this._filename);
+  final String _filename;
+
+  Stream<List<int>> get image1x => File(_filename).openRead();
+  Stream<List<int>> get image2x => File('2.0x/$_filename').openRead();
+  Stream<List<int>> get image3x => File('3.0x/$_filename').openRead();
 }
 
 const List<String> _imageNames = [

--- a/shrine_images/pubspec.yaml
+++ b/shrine_images/pubspec.yaml
@@ -6,11 +6,3 @@ homepage: https://github.com/material-components/material-components-flutter-cod
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"
-
-dependencies:
-  flutter:
-    sdk: flutter
-
-dev_dependencies:
-  flutter_test:
-    sdk: flutter

--- a/shrine_images/pubspec.yaml
+++ b/shrine_images/pubspec.yaml
@@ -5,4 +5,4 @@ author: Will Larche <larche@google.com>
 homepage: https://github.com/material-components/material-components-flutter-codelabs-packages
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  sdk: ">=2.5.0 <3.0.0"


### PR DESCRIPTION
Hey @willlarche, I'd like to use `shrine_images` from a `shelf` server to serve images to a flutter app. Halp?

Work in progress, *DO NOT SUBMIT*