### PR TITLE
Migrate rally_assets and shrine_images to NNBD.

### DIFF
--- a/rally_assets/pubspec.yaml
+++ b/rally_assets/pubspec.yaml
@@ -5,7 +5,7 @@ author: Per Classon <perc@google.com>
 homepage: https://github.com/material-components/material-components-flutter-codelabs-packages
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.10.0-0.0.dev <3.0.0"
 
 dependencies:
   flutter:

--- a/shrine_images/pubspec.yaml
+++ b/shrine_images/pubspec.yaml
@@ -5,7 +5,7 @@ author: Will Larche <larche@google.com>
 homepage: https://github.com/material-components/material-components-flutter-codelabs-packages
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  sdk: ">=2.10.0-0.0.dev <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
As they do not contain code, the migration is trivial.
