### PR TITLE
Fix lower Dart SDK constraint to not point to a dev release

### DIFF
--- a/shrine_images/pubspec.yaml
+++ b/shrine_images/pubspec.yaml
@@ -1,10 +1,10 @@
 name: shrine_images
 description: Image assets for the Material Components for Flutter codelabs based on an app called Shrine.
-version: 2.0.1
+version: 2.0.2
 repository: https://github.com/material-components/material-components-flutter-codelabs-packages
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
The current lower constraint of this package is:
```
  sdk: ">=2.12.0-0 <3.0.0"
```

This means that it doesn't fully support null safety, as that shipped in the 2.12.0 stable release, and `2.12.0-0` is a dev release.

The fix is a small tweak:
```
  sdk: ">=2.12.0 <3.0.0"
```
